### PR TITLE
options for multiple services

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Connect to tweetping realtime channel
 connect(<String|Number> streamId, <String> service, <Function> callback, <String> hostname)
 ```
 
-return a stream (nodejs style)
+return a function to close socket
 
 ### streamId
 
@@ -30,29 +30,16 @@ Server to connect - default: `tweetping.net`
 
 ## Example
 
-### Callback style
 
 ```js
 import connect from 'tweetping-connect';
 
-connect(1193, 'wall', (data) => {
+const close = connect(1193, 'wall', (data) => {
   console.log(data);
 });
+
+
+//close connection 20s later
+setTimeout(close, 20000);
 ```
 
-### Nodejs Stream Style
-
-```js
-import connect from 'tweetping-connect';
-
-const stream = connect(1193, 'wall');
-
-stream.on('data', message => console.log(message));
-//or 
-stream.pipe(process.stdout);
-
-stream.on('error', err => console.log('disconnected :(' );
-
-setTimeout(() => stream.end(), 10000); //close connection after 10s
-
-```

--- a/README.md
+++ b/README.md
@@ -4,54 +4,55 @@ Connect to tweetping realtime channel
 ## Documentation
 
 ```
-connect(<Number> streamId, <Function> onEvent, <Object> options)
+connect(<String|Number> streamId, <String> service, <Function> callback, <String> hostname)
 ```
+
+return a stream (nodejs style)
 
 ### streamId
 
-Number which represent the stream id you want to connect (ex: `1250`)
+Number/String which represent the stream id you want to connect (ex: `1250`)
 
-### onEvent
-
-callback function: what's happening when you receive a new event from tweetping server.
-
-this callback as 2 parameters:
-
-* event type or service which emit this new event
-* data
-
-
-### options
-
-Javascript plain object.
-
-```js
-const options = {
-  sever: 'tweetping.net',
-  services: ['wall', 'cities']
-};
-```
-
-* server: server to connect. default: `tweetping.net`
-* services: array of services you want to be receive notification in real-time. default `['raw']`
+### service
 
 list of services:
 
 * [wall](https://github.com/lightstream-company/wall-projection)
 * ...
 
+### callback
+
+Execute it each time you'll receive a new event from tweetping server.
+
+### hostname
+
+Server to connect - default: `tweetping.net`
 
 ## Example
+
+### Callback style
 
 ```js
 import connect from 'tweetping-connect';
 
-const options = {
- services: ['wall', 'cities' /*, ... */ ]
-};
-connect(1193, (service, data) => {
-  console.log('from service: ' + service);
+connect(1193, 'wall', (data) => {
   console.log(data);
-}, options);
+});
 ```
 
+### Nodejs Stream Style
+
+```js
+import connect from 'tweetping-connect';
+
+const stream = connect(1193, 'wall');
+
+stream.on('data', message => console.log(message));
+//or 
+stream.pipe(process.stdout);
+
+stream.on('error', err => console.log('disconnected :(' );
+
+setTimeout(() => stream.end(), 10000); //close connection after 10s
+
+```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ Number which represent the stream id you want to connect (ex: `1250`)
 
 ### onEvent
 
-call back function: what's happening when you receive a new event from tweetping server
+callback function: what's happening when you receive a new event from tweetping server.
+
+this callback as 2 parameters:
+
+* event type or service which emit this new event
+* data
 
 
 ### options
@@ -44,8 +49,9 @@ import connect from 'tweetping-connect';
 const options = {
  services: ['wall', 'cities' /*, ... */ ]
 };
-connect(1193, (post) => {
-  console.log(post);
+connect(1193, (service, data) => {
+  console.log('from service: ' + service);
+  console.log(data);
 }, options);
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,51 @@
 # tweetping-connect
 Connect to tweetping realtime channel
 
+## Documentation
+
+```
+connect(<Number> streamId, <Function> onEvent, <Object> options)
+```
+
+### streamId
+
+Number which represent the stream id you want to connect (ex: `1250`)
+
+### onEvent
+
+call back function: what's happening when you receive a new event from tweetping server
+
+
+### options
+
+Javascript plain object.
+
+```js
+const options = {
+  sever: 'tweetping.net',
+  services: ['wall', 'cities']
+};
+```
+
+* server: server to connect. default: `tweetping.net`
+* services: array of services you want to be receive notification in real-time. default `['raw']`
+
+list of services:
+
+* [wall](https://github.com/lightstream-company/wall-projection)
+* ...
+
+
 ## Example
 
 ```js
 import connect from 'tweetping-connect';
 
-const URL = 'ws://tweetping.net';
+const options = {
+ services: ['wall', 'cities' /*, ... */ ]
+};
 connect(1193, (post) => {
   console.log(post);
-}, URL);
+}, options);
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tweetping-connect",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Connect to tweetping realtime channel",
   "main": "lib/connect.js",
   "scripts": {

--- a/src/connect.js
+++ b/src/connect.js
@@ -5,8 +5,7 @@ const INITIAL_RETRY_TIMER = 100;
 function defaultUrl() {
   if (typeof window !== 'undefined') {
     const {location} = window.document;
-    const protocol = location.protocol.indexOf('https') ? 'wss' : 'ws';
-    return protocol + '://' + (location.hostname || location.host);
+    return 'wss://' + (location.hostname || location.host);
   } else {
     throw new Error('no default url found, explicit url is required');
   }

--- a/src/connect.js
+++ b/src/connect.js
@@ -27,7 +27,7 @@ export default function connect(streamId, onMessage, url = defaultUrl(), timer =
   });
 
   socket.once('close', () => {
-    if(onMessage){
+    if (onMessage) {
       socket.off('message', parse);
     }
     if (timer < 1000000) {
@@ -36,7 +36,7 @@ export default function connect(streamId, onMessage, url = defaultUrl(), timer =
     setTimeout(() => connect(streamId, onMessage, url, timer), timer);
   });
 
-  if(onMessage){
+  if (onMessage) {
     socket.on('message', parse);
   }
 }

--- a/src/connect.js
+++ b/src/connect.js
@@ -7,7 +7,7 @@ function defaultUrl() {
     const {location} = window.document;
     return 'wss://' + (location.hostname || location.host);
   } else {
-    throw new Error('no default url found, explicit url is required');
+    return 'wss://tweetping.net/';
   }
 }
 

--- a/src/connect.js
+++ b/src/connect.js
@@ -19,7 +19,17 @@ export default function connect(id, service, callback, server = 'tweetping.net',
 
   function onReceiveData(dataString) {
     const firstChar = dataString.charAt(0);
-    const data = (firstChar === '{' || firstChar == '[') ? JSON.parse(dataString) : dataString;
+    const floatParsed = parseFloat(dataString);
+    var data = dataString;
+    if(firstChar === '{' || firstChar == '['){
+      try{
+        data = JSON.parse(dataString);
+      }catch(e){
+        console.log(e);
+      }
+    }else if(!isNaN(floatParsed) && floatParsed.toString() === dataString){
+      data = floatParsed;
+    }
     if(typeof callback === 'function'){
       callback(data);
     }


### PR DESCRIPTION
Tweetping connect should allow to receive different notification for each service in realtime
for example, for the wall we want to receive each new item.
for the activity we want to be notify only that a new item appends (but we do not car about the content).
etc.

I suggest to replace le last parameter `<string> serverUrl` by a javascript plain object which contains différent options. some of them with default values.

For now I identify server and services list.
